### PR TITLE
Update Controllers_Routing.md

### DIFF
--- a/zh-CN/Controllers_Routing.md
+++ b/zh-CN/Controllers_Routing.md
@@ -62,11 +62,11 @@ type ControllerInterface interface {
 可以在 Controlle 中通过如下方式获取上面的变量：
 
 ```go
-this.Ctx.Input.Params(":id")
-this.Ctx.Input.Params(":username")
-this.Ctx.Input.Params(":splat")
-this.Ctx.Input.Params(":path")
-this.Ctx.Input.Params(":ext")
+this.Ctx.Input.Param(":id")
+this.Ctx.Input.Param(":username")
+this.Ctx.Input.Param(":splat")
+this.Ctx.Input.Param(":path")
+this.Ctx.Input.Param(":ext")
 ```
 
 ## 自定义方法及 RESTful 规则


### PR DESCRIPTION
今天更新beego后，发现this.Ctx.Input.Params(":id")改为this.Ctx.Input.Param(":id")了，文档不更新会坑好多人啊
