### PR TITLE
文档API有误，介绍ValuesFlat的地方演示代码用了ValueList

### DIFF
--- a/zh-CN/mvc/model/rawsql.md
+++ b/zh-CN/mvc/model/rawsql.md
@@ -188,7 +188,7 @@ if err == nil && num > 0 {
 
 ```go
 var list orm.ParamsList
-num, err = o.Raw("SELECT id FROM user WHERE id < ?", 10).ValuesList(&list)
+num, err = o.Raw("SELECT id FROM user WHERE id < ?", 10).ValuesFlat(&list)
 if err == nil && num > 0 {
 	fmt.Println(list) // []{"1","2","3",...}
 }


### PR DESCRIPTION
num, err = o.Raw("SELECT id FROM user WHERE id < ?", 10).ValuesList(&list) to  ValuesFlat()
