### PR TITLE
Update ParseForm example

### DIFF
--- a/en-US/mvc/controller/params.md
+++ b/en-US/mvc/controller/params.md
@@ -65,7 +65,7 @@ Parsing in Controller:
 ```go
 func (this *MainController) Post() {
 	u := user{}
-	if err := this.ParseForm(&u); err != nil {
+	if err := this.Request.ParseForm(&u); err != nil {
 		//handle error
 	}
 }


### PR DESCRIPTION
This fixes the error in the example code for parsing form data. It used the `ParseForm` method directly on the controller, while this method is attached to the `revel.Request` type.
