### PR TITLE
Updating Bee tool documentation to reflect current status

### DIFF
--- a/en-US/install/bee.md
+++ b/en-US/install/bee.md
@@ -190,23 +190,17 @@ Note that the new API application doesn't have a static and views folder.
 
 ### Command bale
 
-```
-rwxr-xr-x  1 astaxie  staff  8995376 11 25 22:46 apiproject
--rw-r--r--  1 astaxie  staff  2240288 11 25 22:58 apiproject.tar.gz
-drwxr-xr-x  3 astaxie  staff      102 11 25 22:31 conf
-drwxr-xr-x  3 astaxie  staff      102 11 25 22:31 controllers
--rw-r--r--  1 astaxie  staff      509 11 25 22:31 main.go
-drwxr-xr-x  3 astaxie  staff      102 11 25 22:31 models
-drwxr-xr-x  3 astaxie  staff      102 11 25 22:31 tests
-```
-
-### Command router
-
-This command doesn't work yet. In the future it will generate the routers by analysing the function in controllers.
-
-### Command bale
-
 This command is currently only available to the developer team. It's mainly used for compressing all the static files in to a single binary file. So we don't need to carry  static files including js, css, images and views when publish the project. Those files will be self-extracting with non-overwrite when the program starts.
+
+### Command version
+
+This command displays the version of `bee`, `beego`, and `go`
+
+### Command generate
+This command will generate the routers by analyzing the functions in controllers.
+
+### Command migrate
+This command will run database migration scripts.
 
 ## Bee tool configuration
 

--- a/en-US/install/bee.md
+++ b/en-US/install/bee.md
@@ -124,9 +124,36 @@ After modifying the `default.go` file in the `controllers` folder, we can see th
 
 Refreshing the browser should show the results of the new modifications.
 
+### Command pack
+
+`pack` command is used to compress the project into a single file. Then we can deploy the project by uploading and extracting the zip file to the server.
+
+```
+bee pack
+app path: /gopath/src/apiproject
+GOOS darwin GOARCH amd64
+build apiproject
+build success
+exclude prefix:
+exclude suffix: .go:.DS_Store:.tmp
+file write to `/gopath/src/apiproject/apiproject.tar.gz`
+```
+
+We can see compressed file in the project folder:
+
+```
+rwxr-xr-x  1 astaxie  staff  8995376 11 25 22:46 apiproject
+-rw-r--r--  1 astaxie  staff  2240288 11 25 22:58 apiproject.tar.gz
+drwxr-xr-x  3 astaxie  staff      102 11 25 22:31 conf
+drwxr-xr-x  3 astaxie  staff      102 11 25 22:31 controllers
+-rw-r--r--  1 astaxie  staff      509 11 25 22:31 main.go
+drwxr-xr-x  3 astaxie  staff      102 11 25 22:31 models
+drwxr-xr-x  3 astaxie  staff      102 11 25 22:31 tests
+```
+
 ### Command api
 
-The `new` command is used for crafting new web applications. But there are many users who use beego for developing APIs. We can use the `api` command to create new API applications. 
+The `new` command is used for crafting new web applications. But there are many users who use beego for developing APIs. We can use the `api` command to create new API applications.
 Here is the result of running `bee api project_name`:
 
 ```
@@ -161,45 +188,7 @@ apiproject
 Compare this to the `bee new myproject` command seen earlier.
 Note that the new API application doesn't have a static and views folder.
 
-### Command test
-
-This is a wrapper for `go test`. It can run the test cases in test folder
-of beego project.
-
-```
-bee test apiproject
-13-11-25 10:46:57 [INFO] Initializing watcher...
-13-11-25 10:46:57 [TRAC] Directory(/gopath/src/apiproject/controllers)
-13-11-25 10:46:57 [TRAC] Directory(/gopath/src/apiproject/models)
-13-11-25 10:46:57 [TRAC] Directory(/gopath/src/apiproject)
-13-11-25 10:46:57 [INFO] Start building...
-13-11-25 10:46:58 [SUCC] Build was successful
-13-11-25 10:46:58 [INFO] Restarting apiproject ...
-13-11-25 10:46:58 [INFO] ./apiproject is running...
-13-11-25 10:46:58 [INFO] Start testing...
-13-11-25 10:46:59 [TRAC] ============== Test Begin ===================
-PASS
-ok  	apiproject/tests	0.100s
-13-11-25 10:47:00 [TRAC] ============== Test End ===================
-13-11-25 10:47:00 [SUCC] Test finish
-```
-
-### Command pack
-
-`pack` command is used to compress the project into a single file. Then we can deploy the project by uploading and extracting the zip file to the server.
-
-```
-bee pack
-app path: /gopath/src/apiproject
-GOOS darwin GOARCH amd64
-build apiproject
-build success
-exclude prefix:
-exclude suffix: .go:.DS_Store:.tmp
-file write to `/gopath/src/apiproject/apiproject.tar.gz`
-```
-
-We can see compressed file in the project folder:
+### Command bale
 
 ```
 rwxr-xr-x  1 astaxie  staff  8995376 11 25 22:46 apiproject

--- a/en-US/install/bee.md
+++ b/en-US/install/bee.md
@@ -12,7 +12,7 @@ Bee tool is a project for help develop beego rapidly. With bee tool we can creat
 You can install bee tool through following command:
 
 	go get github.com/beego/bee
-	
+
 `bee` is installed into `GOPATH/bin` by default. You need to add `GOPATH/bin` to your PATH, otherwise the `bee` command won't work.
 
 ## Bee tool commands
@@ -28,14 +28,15 @@ Usage:
 
 The commands are:
 
-    new         create an application base on beego framework
-    run         run the app which can hot compile
-    pack        compress an beego project
-    api         create an api application base on beego framework
-    router      auto-generate routers for the app controllers
-    test        test the app
-    bale        packs non-Go files to Go source files	
-```	
+	new         Create a Beego application
+	run         run the app and start a Web server for development
+	pack        Compress a beego project into a single file
+	api         create an API beego application
+	bale        packs non-Go files to Go source files
+	version     show the Bee, Beego and Go version
+	generate    source code generator
+	migrate     run database migrations
+```
 
 ### Command `new`
 


### PR DESCRIPTION
When I hit `bee help` today, I noticed that the output is different from the documentation.

I updated this to the best of my knowledge. The `pack` section wasn't edited at all, just simply moved to match the `help` output order.

I deleted commands that no longer appear in `help` and also stubbed out some of the other features that were missing. I'd be willing to work on better documentation for the stubbed out features if someone provides some guidance or backstory on them.