### PR TITLE
没有SessionSavePath的配置选项，应该修改为SessionProviderConfig

### DIFF
--- a/zh-CN/mvc/controller/session.md
+++ b/zh-CN/mvc/controller/session.md
@@ -74,9 +74,9 @@ sess 对象具有如下方法：
 
 	设置 Session 过期的时间，默认值是 3600 秒，配置文件对应的参数：sessiongcmaxlifetime。
 
-- SessionSavePath
+- SessionProviderConfig
 
-	设置对应 file、mysql、redis 引擎的保存路径或者链接地址，默认值是空，配置文件对应的参数：sessionsavepath。
+	设置对应 file、mysql、redis 引擎的保存路径或者链接地址，默认值是空，配置文件对应的参数：sessionproviderconfig。
 	
 - SessionHashFunc
 

--- a/zh-CN/mvc/controller/session.md
+++ b/zh-CN/mvc/controller/session.md
@@ -100,33 +100,33 @@ sess 对象具有如下方法：
 
 当 SessionProvider 为 file 时，SessionSavePath 是只保存文件的目录，如下所示：
 
-	beego.SessionProvider = "file"
-	beego.SessionSavePath = "./tmp"
+	beego.BConfig.WebConfig.Session.SessionProvider = "file"
+	beego.BConfig.WebConfig.Session.SessionProviderConfig = "./tmp"
 
-当 SessionProvider 为 mysql 时，SessionSavePath 是链接地址，采用 [go-sql-driver](https://github.com/go-sql-driver/mysql)，如下所示：
+当 SessionProvider 为 mysql 时，SessionProviderConfig 是链接地址，采用 [go-sql-driver](https://github.com/go-sql-driver/mysql)，如下所示：
 
-	beego.SessionProvider = "mysql"
-	beego.SessionSavePath = "username:password@protocol(address)/dbname?param=value"
+	beego.BConfig.WebConfig.Session.SessionProvider = "mysql"
+	beego.BConfig.WebConfig.Session.SessionProviderConfig = "username:password@protocol(address)/dbname?param=value"
 
-当 SessionProvider 为 redis 时，SessionSavePath 是 redis 的链接地址，采用了 [redigo](https://github.com/garyburd/redigo)，如下所示：
+当 SessionProvider 为 redis 时，SessionProviderConfig 是 redis 的链接地址，采用了 [redigo](https://github.com/garyburd/redigo)，如下所示：
 
-	beego.SessionProvider = "redis"
-	beego.SessionSavePath = "127.0.0.1:6379"
+	beego.BConfig.WebConfig.Session.SessionProvider = "redis"
+	beego.BConfig.WebConfig.Session.SessionProviderConfig = "127.0.0.1:6379"
 	
-当 SessionProvider 为 memcache 时，SessionSavePath 是 memcache 的链接地址，采用了 [memcache](https://github.com/beego/memcache)，如下所示：
+当 SessionProvider 为 memcache 时，SessionProviderConfig 是 memcache 的链接地址，采用了 [memcache](https://github.com/beego/memcache)，如下所示：
 
-	beego.SessionProvider = "memcache"
-	beego.SessionSavePath = "127.0.0.1:7080"
+	beego.BConfig.WebConfig.Session.SessionProvider = "memcache"
+	beego.BConfig.WebConfig.Session.SessionProviderConfig = "127.0.0.1:7080"
 	
-当 SessionProvider 为 postgres 时，SessionSavePath 是 postgres 的链接地址，采用了 [postgres](https://github.com/lib/pq)，如下所示：
+当 SessionProvider 为 postgres 时，SessionProviderConfig 是 postgres 的链接地址，采用了 [postgres](https://github.com/lib/pq)，如下所示：
 
-	beego.SessionProvider = "postgresql"
-	beego.SessionSavePath = "postgres://pqgotest:password@localhost/pqgotest?sslmode=verify-full"
+	beego.BConfig.WebConfig.Session.SessionProvider = "postgresql"
+	beego.BConfig.WebConfig.Session.SessionProviderConfig = "postgres://pqgotest:password@localhost/pqgotest?sslmode=verify-full"
 	
-当 SessionProvider 为 couchbase 时，SessionSavePath 是 couchbase 的链接地址，采用了 [couchbase](https://github.com/couchbaselabs/go-couchbase)，如下所示：
+当 SessionProvider 为 couchbase 时，SessionProviderConfig 是 couchbase 的链接地址，采用了 [couchbase](https://github.com/couchbaselabs/go-couchbase)，如下所示：
 
-	beego.SessionProvider = "couchbase"
-	beego.SessionSavePath = "http://bucketname:bucketpass@myserver:8091/"		
+	beego.BConfig.WebConfig.Session.SessionProvider = "couchbase"
+	beego.BConfig.WebConfig.Session.SessionProviderConfig = "http://bucketname:bucketpass@myserver:8091"
     
     
 ## 特别注意点


### PR DESCRIPTION
@astaxie  , 测试了一下，配置sessionSavePath选项没有效果，看了一下BConfig.Webconfig.Session中没有该选项，
```
type SessionConfig struct {
	SessionOn             bool
	SessionProvider       string
	SessionName           string
	SessionGCMaxLifetime  int64
	SessionProviderConfig string
	SessionCookieLifeTime int
	SessionAutoSetCookie  bool
	SessionDomain         string
}
```
测试了一下 provider为file情况下的sessionproviderconfig为./tmp 选项是可以的，app.conf如下：
```
sessionprovider = file
Sessionproviderconfig = ./tmp
```
redis 和 mysql 没有测试。