### PR TITLE
文档中的端口与地址参数有误

### DIFF
--- a/zh-CN/advantage/monitor.md
+++ b/zh-CN/advantage/monitor.md
@@ -15,8 +15,8 @@ sort: 1
 	
 而且你还可以修改监听的地址和端口：
 
-	AdminAddr = "localhost"
-	AdminPort = 8088
+	AdminHttpAddr = "localhost"
+	AdminHttpPort = 8088
 	
 打开浏览器，输入 URL：`http://localhost:8088/`，你会看到一句欢迎词：`Welcome to Admin Dashboard`。
 


### PR DESCRIPTION
文档中的端口与地址参数有误
代码如下:
````````
	if strings.HasSuffix(file, ".conf") {
		fixed = strings.Replace(fixed, "HttpCertFile", "HTTPSCertFile", -1)
		fixed = strings.Replace(fixed, "HttpKeyFile", "HTTPSKeyFile", -1)
		fixed = strings.Replace(fixed, "EnableHttpListen", "HTTPEnable", -1)
		fixed = strings.Replace(fixed, "EnableHttpTLS", "EnableHTTPS", -1)
		fixed = strings.Replace(fixed, "EnableHttpTLS", "EnableHTTPS", -1)
		fixed = strings.Replace(fixed, "BeegoServerName", "ServerName", -1)
                //使用AdminAddr替换AdminHttpAddr，所以文档中的参数没生效。
		fixed = strings.Replace(fixed, "AdminHttpAddr", "AdminAddr", -1)
		fixed = strings.Replace(fixed, "AdminHttpPort", "AdminPort", -1)
		fixed = strings.Replace(fixed, "HttpServerTimeOut", "ServerTimeOut", -1)
	}
`````````