### PR TITLE
Update SessionOn variable on session.md

### DIFF
--- a/en-US/mvc/controller/session.md
+++ b/en-US/mvc/controller/session.md
@@ -9,7 +9,7 @@ Beego has a built-in session module. It supports memory, file, mysql, redis, cou
 
 It is very easy to use session in Beego, just switch session on in the main function:
 
-	beego.SessionOn = true
+	beego.BConfig.WebConfig.Session.SessionOn = true
 
 Or you can switch it on in the configuration file:
 


### PR DESCRIPTION
Current version no longer works with beego.SessionOn variable at a default behavior.
Replace this with beego.BConfig.WebConfig.Session.SessionOn = true which is the 
option that works on default if user chooses to place this value on main function.