### PR TITLE
_ "beeapi/docs"引入说明补充

### DIFF
--- a/zh-CN/advantage/docs.md
+++ b/zh-CN/advantage/docs.md
@@ -157,7 +157,7 @@ func (c *CMSController) Product() {
 要使得文档工作，你需要做几个事情，
 
 - 第一开启应用内文档开关，在配置文件中设置：`EnableDocs = true`,
-- 然后在你的 `main.go` 函数中引入 `_ "beeapi/docs"`。
+- 然后在你的 `main.go` 函数中引入 `_ "beeapi/docs"`（beego 1.7.0 之后版本不需要添加该引用）。
 - 这样你就已经内置了 docs 在你的 API 应用中，然后你就使用 `bee run -gendoc=true -downdoc=true`,让我们的 API 应用跑起来，`-gendoc=true` 表示每次自动化的 build 文档，`-downdoc=true` 就会自动的下载 swagger 文档查看器
 
 好了，现在打开你的浏览器查看一下效果，是不是已经完美了。下面是我的 API 文档效果：


### PR DESCRIPTION
beego1.7.0版本中的swagger不再需要依赖docs/docs.go文件，故不需要添加在 `main.go` 函数中引入 `_  beeapi/docs"`
参见：https://github.com/astaxie/beego/issues/2164