### PR TITLE
Update orm.md connection string documentation

### DIFF
--- a/en-US/mvc/model/orm.md
+++ b/en-US/mvc/model/orm.md
@@ -124,6 +124,8 @@ maxConn := 30
 orm.RegisterDataBase("default", "mysql", "root:root@/orm_test?charset=utf8", maxIdle, maxConn)
 ```
 
+See [Test.md](https://beego.me/docs/mvc/model/test.md) for more information on database connection strings.
+
 #### SetMaxIdleConns
 
 Set maximum idle connections according to database alias:


### PR DESCRIPTION
Added link for further information on database connection strings, this is a bit confusing for postgres as it does not take the standard postgres connection string. So this link at this point in the the documentation will prevent the reader from missing this path.