### PR TITLE
修正统一各语言中admin端口开启的配置示例

### DIFF
--- a/en-US/advantage/monitor.md
+++ b/en-US/advantage/monitor.md
@@ -15,8 +15,8 @@ Monitor is disabled by default. You can enable it by adding the following line i
 
 Also you can change the port it listens on:
 
-	AdminHttpAddr = "localhost"
-	AdminHttpPort = 8088
+	AdminAddr = "localhost"
+	AdminPort = 8088
 
 Open browser and visit `http://localhost:8088/` you will see `Welcome to Admin Dashboard`.
 

--- a/ru-RU/advantage/monitor.md
+++ b/ru-RU/advantage/monitor.md
@@ -11,12 +11,12 @@ sort: 1
 
 Мониторинг выключен по умолчанию. Вы можете включить его:
 
-	beego.EnableAdmin = true
+	EnableAdmin = true
 
 И вы можете изменить порт, на котором работает мониторинг:
 
-	beego.AdminHttpAddr = "localhost"
-	beego.AdminHttpPort = 8888
+	AdminAddr = "localhost"
+	AdminPort = 8888
 
 Откройте в браузере `http://localhost:8088/` и вы увидите `Welcome to Admin Dashboard`.
 

--- a/zh-CN/advantage/monitor.md
+++ b/zh-CN/advantage/monitor.md
@@ -11,12 +11,12 @@ sort: 1
 
 默认监控是关闭的，你可以通过设置参数配置开启监控：
 
-	enableadmin = true
+	EnableAdmin = true
 
 而且你还可以修改监听的地址和端口：
 
-	adminaddr = "localhost"
-	adminport = 8088
+	AdminAddr = "localhost"
+	AdminPort = 8088
 
 打开浏览器，输入 URL：`http://localhost:8088/`，你会看到一句欢迎词：`Welcome to Admin Dashboard`。
 

--- a/zh-CN/advantage/monitor.md
+++ b/zh-CN/advantage/monitor.md
@@ -11,12 +11,12 @@ sort: 1
 
 默认监控是关闭的，你可以通过设置参数配置开启监控：
 
-	beego.EnableAdmin = true
+	enableadmin = true
 
 而且你还可以修改监听的地址和端口：
 
-	beego.AdminAddr = "localhost"
-	beego.AdminPort = 8088
+	adminaddr = "localhost"
+	adminport = 8088
 
 打开浏览器，输入 URL：`http://localhost:8088/`，你会看到一句欢迎词：`Welcome to Admin Dashboard`。
 


### PR DESCRIPTION
最新版本的beego中，admin相关的配置命名做了更新，这里同步下更新