### PR TITLE
Fix rel_through doc

### DIFF
--- a/en-US/mvc/model/models.md
+++ b/en-US/mvc/model/models.md
@@ -278,7 +278,7 @@ You can set these as follows:
 
 `orm:"rel(m2m);rel_table(the_table_name)"`
 
-`orm:"rel(m2m);rel_through(pkg.path.ModelName)"`
+`orm:"rel(m2m);rel_through(project_path/current_package.ModelName)"`
 
 #### on_delete
 


### PR DESCRIPTION
I tested rel_through and it worked like that: rel_through(my_api/models.Test), so I propose this change.