### PR TITLE
修改文档中初始化session配置

### DIFF
--- a/zh-CN/module/session.md
+++ b/zh-CN/module/session.md
@@ -32,16 +32,14 @@ session 模块参考了 `database/sql` 的引擎写法，采用了一个接口�
 接着在你的入口函数中初始化数据：
 
 	func init() {
-		sessionConfig := &session.ManagerConfig{
-		"cookieName":"gosessionid", 
-		"enableSetCookie,omitempty": true, 
-		"gclifetime":3600,
-		"maxLifetime": 3600, 
-		"secure": false,
-		"sessionIDHashFunc": "sha1", 
-		"sessionIDHashKey": "",
-		"cookieLifeTime": 3600,
-		"providerConfig": ""
+	        sessionConfig := &session.ManagerConfig{
+		CookieName:"gosessionid", 
+		EnableSetCookie: true, 
+		Gclifetime:3600,
+		Maxlifetime: 3600, 
+		Secure: false,
+		CookieLifeTime: 3600,
+		ProviderConfig: "./tmp",
 		}
 		globalSessions, _ = session.NewManager("memory",sessionConfig)
 		go globalSessions.GC()

--- a/zh-CN/module/session.md
+++ b/zh-CN/module/session.md
@@ -32,7 +32,18 @@ session 模块参考了 `database/sql` 的引擎写法，采用了一个接口�
 接着在你的入口函数中初始化数据：
 
 	func init() {
-		globalSessions, _ = session.NewManager("memory", `{"cookieName":"gosessionid", "enableSetCookie,omitempty": true, "gclifetime":3600, "maxLifetime": 3600, "secure": false, "sessionIDHashFunc": "sha1", "sessionIDHashKey": "", "cookieLifeTime": 3600, "providerConfig": ""}`)
+		sessionConfig := &session.ManagerConfig{
+		"cookieName":"gosessionid", 
+		"enableSetCookie,omitempty": true, 
+		"gclifetime":3600,
+		"maxLifetime": 3600, 
+		"secure": false,
+		"sessionIDHashFunc": "sha1", 
+		"sessionIDHashKey": "",
+		"cookieLifeTime": 3600,
+		"providerConfig": ""
+		}
+		globalSessions, _ = session.NewManager("memory",sessionConfig)
 		go globalSessions.GC()
 	}
 


### PR DESCRIPTION
初始化需要将参数传入&session.ManagerConfig的结构体，否则会报
cannot use "{***}" (type string) as type *session.ManagerConfig in argument to session.NewManager