### PR TITLE
Modify the parsing body example, add error check, so that invalid JSON error will be sent to client

### DIFF
--- a/zh-CN/mvc/controller/params.md
+++ b/zh-CN/mvc/controller/params.md
@@ -88,9 +88,13 @@ func (this *MainController) Post() {
 ```go
 func (this *ObjectController) Post() {
 	var ob models.Object
-	json.Unmarshal(this.Ctx.Input.RequestBody, &ob)
-	objectid := models.AddOne(ob)
-	this.Data["json"] = "{\"ObjectId\":\"" + objectid + "\"}"
+	var err error
+	if err = json.Unmarshal(this.Ctx.Input.RequestBody, &ob); err == nil {
+	    objectid := models.AddOne(ob)
+	    this.Data["json"] = "{\"ObjectId\":\"" + objectid + "\"}"
+	} else {
+	    this.Data["json"] = err.Error()
+	}
 	this.ServeJSON()
 }
 ```


### PR DESCRIPTION
Modify the parsing body example, add error check, so that invalid JSON error will be sent to client
```
func (this *ObjectController) Post() {
    var ob models.Object
    json.Unmarshal(this.Ctx.Input.RequestBody, &ob)
    objectid := models.AddOne(ob)
    this.Data["json"] = "{\"ObjectId\":\"" + objectid + "\"}"
    this.ServeJSON()
}
```
```
if err = json.Unmarshal(this.Ctx.Input.RequestBody, &ob); err == nil {
}
```

