### PR TITLE
Update router.md

### DIFF
--- a/zh-CN/mvc/controller/router.md
+++ b/zh-CN/mvc/controller/router.md
@@ -92,7 +92,7 @@ beego.Handler("/rpc", s)
 
 	自定义正则匹配 //匹配 /api/123 :id = 123
 
-- beego.Router("/user/:username([\\w]+)", &controllers.RController{})
+- beego.Router("/user/:username([\\\\w]+)", &controllers.RController{})
 
 	正则字符串匹配 //匹配 /user/astaxie :username = astaxie
 


### PR DESCRIPTION
markdown 显示的正则字符串匹配代码 只有一个/
beego.Router(“/user/:username([\w]+)“, &controllers.RController{})
//匹配 /user/astaxie :username = astaxie
加两个//之后 markdown渲染之后的代码显示正确