### PR TITLE
Update Controller Quickstart Tutorial

### DIFF
--- a/en-US/quickstart/controller.md
+++ b/en-US/quickstart/controller.md
@@ -18,10 +18,10 @@ type MainController struct {
         beego.Controller
 }
 
-func (this *MainController) Get() {
-        this.Data["Website"] = "beego.me"
-        this.Data["Email"] = "astaxie@gmail.com"
-        this.TplNames = "index.tpl" // version 1.6 use this.TplName = "index.tpl"
+func (c *MainController) Get() {
+        c.Data["Website"] = "beego.me"
+        c.Data["Email"] = "astaxie@gmail.com"
+        c.TplNames = "index.tpl" // version 1.6 use this.TplName = "index.tpl"
 }
 ```
 
@@ -37,9 +37,9 @@ We talked about the fact that Beego is a RESTful framework so our requests will 
 
 ## The `Get` method
 
-The logic of the `Get` method only outputs data. This data will be stored in `this.Data`, a `map[interface{}]interface{}`.  Any type of data can be assigned here. In this case only two strings are assigned.
+The logic of the `Get` method only outputs data. This data will be stored in `c.Data`, a `map[interface{}]interface{}`.  Any type of data can be assigned here. In this case only two strings are assigned.
 
-Finally the template will be rendered. `this.TplNames` (v1.6 uses `this.TplName`) specifies the template which will be rendered. In this case it is `index.tpl`.  If a template is not set it will default to `controller/method_name.tpl`. For example, in this case it would try to find `maincontroller/get.tpl`.
+Finally the template will be rendered. `c.TplNames` (v1.6 uses `this.TplName`) specifies the template which will be rendered. In this case it is `index.tpl`.  If a template is not set it will default to `controller/method_name.tpl`. For example, in this case it would try to find `maincontroller/get.tpl`.
 
 There is no need to render manually.  Beego will call the `Render` function (which is implemented in `beego.Controller`) automatically if it is set up in the template.
 


### PR DESCRIPTION
Tutorial still maintains the use of "this" as variable name for MainController struct. Bee v1.10.0 generates new projects using "c" as variable name for MainController struct instead of "this". The use of "this" conflicts with the latest version of Bee and it is very likely for the tutorial to create confusion in people that are new to Beego.