### PR TITLE
Change TplNames to TplName

### DIFF
--- a/en-US/Controllers_IntegrateApp.md
+++ b/en-US/Controllers_IntegrateApp.md
@@ -55,7 +55,7 @@ type MainController struct {
 }
 
 func (m *MainController) Get() {
-	m.TplNames = "index.html"
+	m.TplName = "index.html"
 }
 
 func main() {

--- a/en-US/mvc/controller/errors.md
+++ b/en-US/mvc/controller/errors.md
@@ -26,7 +26,7 @@ func (this *MainController) Get() {
 		this.SetSession("asta", v.(int)+1)
 		this.Data["Email"] = v.(int)
 	}
-	this.TplNames = "index.tpl"
+	this.TplName = "index.tpl"
 }
 ```
 

--- a/en-US/mvc/controller/flash.md
+++ b/en-US/mvc/controller/flash.md
@@ -13,14 +13,14 @@ func (c *MainController) Get() {
     flash := beego.ReadFromRequest(&c.Controller)
     if n, ok := flash.Data["notice"]; ok {
         // Display settings successful
-        c.TplNames = "set_success.html"
+        c.TplName = "set_success.html"
     } else if n, ok = flash.Data["error"]; ok {
         // Display error messages
-        c.TplNames = "set_error.html"
+        c.TplName = "set_error.html"
     } else {
         // Display default settings page
         this.Data["list"] = GetInfo()
-        c.TplNames = "setting_list.html"
+        c.TplName = "setting_list.html"
     }
 }
 

--- a/en-US/mvc/controller/session.md
+++ b/en-US/mvc/controller/session.md
@@ -27,7 +27,7 @@ func (this *MainController) Get() {
 		this.SetSession("asta", v.(int)+1)
 		this.Data["num"] = v.(int)
 	}
-	this.TplNames = "index.tpl"
+	this.TplName = "index.tpl"
 }
 ```
 

--- a/en-US/quickstart/controller.md
+++ b/en-US/quickstart/controller.md
@@ -21,7 +21,7 @@ type MainController struct {
 func (this *MainController) Get() {
         this.Data["Website"] = "beego.me"
         this.Data["Email"] = "astaxie@gmail.com"
-        this.TplNames = "index.tpl" // version 1.6 use this.TplName = "index.tpl"
+        this.TplName = "index.tpl" // version 1.6 use this.TplName = "index.tpl"
 }
 ```
 
@@ -39,7 +39,7 @@ We talked about the fact that Beego is a RESTful framework so our requests will 
 
 The logic of the `Get` method only outputs data. This data will be stored in `this.Data`, a `map[interface{}]interface{}`.  Any type of data can be assigned here. In this case only two strings are assigned.
 
-Finally the template will be rendered. `this.TplNames` (v1.6 uses `this.TplName`) specifies the template which will be rendered. In this case it is `index.tpl`.  If a template is not set it will default to `controller/method_name.tpl`. For example, in this case it would try to find `maincontroller/get.tpl`.
+Finally the template will be rendered. `this.TplName` (v1.6 uses `this.TplName`) specifies the template which will be rendered. In this case it is `index.tpl`.  If a template is not set it will default to `controller/method_name.tpl`. For example, in this case it would try to find `maincontroller/get.tpl`.
 
 There is no need to render manually.  Beego will call the `Render` function (which is implemented in `beego.Controller`) automatically if it is set up in the template.
 

--- a/en-US/quickstart/view.md
+++ b/en-US/quickstart/view.md
@@ -5,7 +5,7 @@ sort: 5
 
 # Creating views
 
-In the previous example, when creating the Controller the line `this.TplNames = "index.tpl"` was used to declare the template to be rendered.  By default `beego.Controller` supports `tpl` and `html` extensions. Other extensions can be added by calling `beego.AddTemplateExt`.
+In the previous example, when creating the Controller the line `this.TplName = "index.tpl"` was used to declare the template to be rendered.  By default `beego.Controller` supports `tpl` and `html` extensions. Other extensions can be added by calling `beego.AddTemplateExt`.
 
 Beego uses the default `html/template` engine built into Go, so view displays show data using standard Go templates. You can find more information about using Go templates at [*Building Web Applications with Golang*](https://github.com/Unknwon/build-web-application-with-golang_EN/blob/master/eBook/07.4.md).
 


### PR DESCRIPTION
According to the [current documentation about controller funcs](https://beego.me/docs/mvc/controller/controller.md) the function `this.TplNames` has changed to `this.TplName` in version 1.6. But this is not noted on every part of the docs using `this.TplNames`.
Therefore I changed it to the newer version. (And because of version 1.6 was released on January 2016)