### PR TITLE
更正示例文档

### DIFF
--- a/zh-CN/module/cache.md
+++ b/zh-CN/module/cache.md
@@ -48,7 +48,7 @@ beego 的 cache 模块是用来做数据缓存的，设计思路来自于 `datab
 
 	配置信息如下所示，配置 `CachePath` 表示缓存的文件目录，`FileSuffix` 表示文件后缀，`DirectoryLevel` 表示目录层级，`EmbedExpiry` 表示过期设置
 
-		{"CachePath":"./cache","FileSuffix":".cache","DirectoryLevel":2,"EmbedExpiry":120}
+		{"CachePath":"./cache","FileSuffix":".cache","DirectoryLevel":"2","EmbedExpiry":"120"}
 
 - redis
 


### PR DESCRIPTION
cache 的 file 引擎配置的键、值的值都必须为字符串；