### PR TITLE
Update quickstart.md

### DIFF
--- a/en-US/quickstart.md
+++ b/en-US/quickstart.md
@@ -56,7 +56,8 @@ Once it's running, open a browser to [http://localhost:8080/](http://localhost:8
 ## Simple example
 
 The following example prints `Hello world` to your browser, it shows how easy it is to build a web application with beego.
-```go
+```
+go
 package main
 
 import (


### PR DESCRIPTION
Markdown is rendered on https://beego.me/quickstart and the lack of a newline after ``` means code block is poorly formatted.