### PR TITLE
删除容易让人误解的错误SessionProviderConfig值

### DIFF
--- a/zh-CN/mvc/controller/session.md
+++ b/zh-CN/mvc/controller/session.md
@@ -107,7 +107,7 @@ sess 对象具有如下方法：
 当 SessionProvider 为 mysql 时，SessionProviderConfig 是链接地址，采用 [go-sql-driver](https://github.com/go-sql-driver/mysql)，如下所示：
 
 	beego.BConfig.WebConfig.Session.SessionProvider = "mysql"
-	beego.BConfig.WebConfig.Session.SessionProviderConfig = "username:password@protocol(address)/dbname?param=value"
+	beego.BConfig.WebConfig.Session.SessionProviderConfig = "username:password@protocol(address)/dbname"
 
     需要特别注意的是，在使用 mysql 存储 session 信息的时候，需要事先在 mysql 创建表，建表语句如下
 


### PR DESCRIPTION
在设置 beego.BConfig.WebConfig.Session.SessionProviderConfig 的示例中，不应该添加"?param=value"这个存在错误的参数。如果一个对 mysql 不是很熟悉的人，将这段代码复制到他的项目里时，会发现 session 数据在 mysql 中没有被创建（正是因为"SessionProviderConfig "值存在错误，导致连接 mysql 失败），并且没有任何错误与日志输出（连接 mysql 失败的错误被吞掉了，没有正确打印，这是额外的一个问题）