### PR TITLE
Update httplib.md

### DIFF
--- a/en-US/module/httplib.md
+++ b/en-US/module/httplib.md
@@ -23,7 +23,7 @@ Initialize request method and url:
 
 Send the request and retrieve the data in the response:
 
-	str, err := res.String()
+	str, err := req.String()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
In the example you create a variable called `req` and to get its response you refers as `res` but that variable doesn't exists so i guess is `req.String()`