### PR TITLE
删除定义多字段索引和多字段唯一键说明中多余的 '[]string'

### DIFF
--- a/zh-CN/mvc/model/models.md
+++ b/zh-CN/mvc/model/models.md
@@ -48,14 +48,14 @@ type User struct {
 // 多字段索引
 func (u *User) TableIndex() [][]string {
 	return [][]string{
-		[]string{"Id", "Name"},
+		{"Id", "Name"},
 	}
 }
 
 // 多字段唯一键
 func (u *User) TableUnique() [][]string {
 	return [][]string{
-		[]string{"Name", "Email"},
+		{"Name", "Email"},
 	}
 }
 ```


### PR DESCRIPTION
定义多字段索引和多字段唯一键中不需要写 `[]string`