### PR TITLE
Update models.md

### DIFF
--- a/en-US/mvc/model/models.md
+++ b/en-US/mvc/model/models.md
@@ -244,7 +244,7 @@ type User struct {
 
 ## Relationships
 
-#### One to one
+### One to one
 
 **RelOneToOne**:
 
@@ -266,9 +266,9 @@ type Profile struct {
 }
 ```
 
-#### One to many
+### One to many
 
-**RelForeignKey**:
+The initial referenced foreign key, `RelForeignKey`:
 
 ```go
 type Post struct {
@@ -278,7 +278,7 @@ type Post struct {
 }
 ```
 
-The reverse relationship **RelReverseMany**:
+The reversed relationship, `RelReverseMany`:
 
 ```go
 type User struct {


### PR DESCRIPTION
The `One To Many` section felt a bit unreadable because using `####` and `**Content**` have the same font size. I changed `####` to be `###`, and provided sub-text for the below foreign key explanations.

This is a preview. For consistency, this change should be reflected in other sections.

I request feedback from the maintainers over their preference. I would be happy to produce a PR artifact for further changes if this change is appreciated.

Thank you.